### PR TITLE
Compare-GitTree now accepts either a path string via RepositoryRoot p…

### DIFF
--- a/LibGit2.PowerShell.nuspec
+++ b/LibGit2.PowerShell.nuspec
@@ -15,7 +15,7 @@
 <package>
   <metadata>
     <id>LibGit2.PowerShell</id>
-    <version>0.6.0</version>
+    <version>0.7.0</version>
     <authors>Aaron Jensen</authors>
     <owners>Aaron Jensen</owners>
     <licenseUrl>http://www.apache.org/licenses/LICENSE-2.0</licenseUrl>
@@ -27,7 +27,7 @@
 This module uses the .NET wrapper of [libgit2](https://libgit2.github.com/), "a portable, pure C implementation of... Git", which allows you to call Git via API instead using the Git command line interface.</description>
     <language>en-us</language>
     <releaseNotes>
-* Added functionality to `Get-GitCommit` for getting a list of commits between two specified commits.
+* `Compare-GitTree` now accepts either a path to the repository with the `RepositoryRoot` parameter or a repository object with the `RepositoryObject` parameter.
     </releaseNotes>
     <copyright>Copyright 2016 Aaron Jensen</copyright>
     <tags>git vcs rcs automation github gitlab libgit2</tags>

--- a/LibGit2/LibGit2.psd1
+++ b/LibGit2/LibGit2.psd1
@@ -16,7 +16,7 @@
 RootModule = 'LibGit2.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.6.0'
+ModuleVersion = '0.7.0'
 
 # ID used to uniquely identify this module
 GUID = '119a2511-62d9-4626-9728-0c8ec7068c57'
@@ -141,7 +141,7 @@ PrivateData = @{
 
         # ReleaseNotes of this module
         ReleaseNotes = @'
-* Added functionality to `Get-GitCommit` for getting a list of commits between two specified commits.
+* `Compare-GitTree` now accepts either a path to the repository with the `RepositoryRoot` parameter or a repository object with the `RepositoryObject` parameter.
 '@
 
     } # End of PSData hashtable

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+# 0.7.0 (27 October 2017)
+
+ * `Compare-GitTree` now accepts either a path to the repository with the `RepositoryRoot` parameter or a repository object with the `RepositoryObject` parameter.
+
 # 0.6.0 (25 October 2017)
 
  * Added functionality to `Get-GitCommit` for getting a list of commits between two specified commits.

--- a/Source/LibGit2.Automation/Properties/AssemblyInfo.cs
+++ b/Source/LibGit2.Automation/Properties/AssemblyInfo.cs
@@ -43,6 +43,6 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("0.5.0")]
-[assembly: AssemblyVersion("0.5.0")]
-[assembly: AssemblyFileVersion("0.5.0")]
+// [assembly: AssemblyVersion("0.7.0")]
+[assembly: AssemblyVersion("0.7.0")]
+[assembly: AssemblyFileVersion("0.7.0")]


### PR DESCRIPTION
…arameter or a repository object via RepositoryObject parameter